### PR TITLE
Add required configuration for supporting Docsearch

### DIFF
--- a/templates/Rules
+++ b/templates/Rules
@@ -44,10 +44,6 @@ route '/bootstrap/**/*' do
   @item.identifier.to_s
 end
 
-route '/tipuesearch/**/*' do
-  @item.identifier.to_s
-end
-
 # Select which .md.erb becomes the home page of the site
 route HOME_PAGE do
   '/index.html'
@@ -58,8 +54,6 @@ route '/**/*' do
     raise RuntimeError, "Missing required extension: \".#{item.identifier}\""
   elsif item.binary?
     item.identifier.to_s
-  elsif item.identifier == "/searchtipuesearch_content/"
-    item.identifier.chop + '.' + item[:extension] rescue fail "in route * in Rules"
   elsif item[:status] == "hidden"
     nil
   elsif item[:type] == "subsection"

--- a/templates/content/bootstrap/css/custom.css
+++ b/templates/content/bootstrap/css/custom.css
@@ -81,16 +81,27 @@ h6 {
   color: rgb(64, 56, 207);
 }
 
-h3 {
+h1 {
   padding-top: 20px;
+  font-size: 1.75rem;
 }
 
-h4 {
+h2 {
   margin-top: 20px;
   border-top: rgb(64, 56, 207) solid 2px;
   padding-top: 5px;
+  font-size: 1.5rem;
 }
 
+h3 {
+  font-size: 1.25rem;
+}
+
+h4 {
+  font-size: 1rem;
+}
+
+/* Table use only */
 h5 {
   margin-top: 15px;
   font-weight: bold;
@@ -150,75 +161,9 @@ footer {
   font-size: 10px;
 }
 
-/* Search Page */
-
 .h01 {
   color: red;
   font-weight: bold;
-}
-
-#tipue_search_results_count {
-  font-size: 14px;
-  color: red;
-  font-family: telex;
-}
-
-.tipue_search_content_title {
-  color: purple;
-  font-size: 16px;
-  margin-top: 15px;
-  margin-left: 10px;
-  text-rendering: optimizelegibility;
-  font-family: telex;
-}
-
-.tipue_search_content_text {
-  font-size: 14px;
-  margin-left: 30px;
-}
-
-div.tipue_search_content_loc a {
-  font-size: 14px;
-  margin-left: 20px;
-  display: none;
-}
-
-#tipue_search_foot {
-  margin: 51px 0 21px 0;
-}
-#tipue_search_foot_boxes {
-  padding: 0;
-  margin: 0;
-  font: 12px/1 "Open Sans", sans-serif;
-}
-#tipue_search_foot_boxes li {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: inline;
-}
-#tipue_search_foot_boxes li a {
-  padding: 9px 15px 10px 15px;
-  background-color: #f1f1f1;
-  border: 1px solid #dcdcdc;
-  border-radius: 1px;
-  color: #333;
-  margin-right: 7px;
-  text-decoration: none;
-  text-align: center;
-}
-#tipue_search_foot_boxes li.current {
-  padding: 9px 15px 10px 15px;
-  background: #fff;
-  border: 1px solid #dcdcdc;
-  border-radius: 1px;
-  color: #333;
-  margin-right: 7px;
-  text-align: center;
-}
-#tipue_search_foot_boxes li a:hover {
-  border: 1px solid #ccc;
-  background-color: #f3f3f3;
 }
 
 .helpful {

--- a/templates/content/content/index.md.erb
+++ b/templates/content/content/index.md.erb
@@ -3,7 +3,7 @@ title: Welcome!
 section: extras
 ---
 <div class="jumbotron">
-	<h2>Welcome to the Sample Course!</h2>
+	<h1>Welcome to the Sample Course!</h1>
 	<p>This course is generated when you first install Coursegen. It uses all the features (almost) of the software, to allow you to see what is possible.</p>
 
 	<p>Pito Salas, pitosalas@brandeis.edu</p>

--- a/templates/content/content/intro/welcome.md.erb
+++ b/templates/content/content/intro/welcome.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Welcome to Sample Course
 ---
-### Welcome!
+## Welcome!
 
 This page is part of the sample course in Coursegen

--- a/templates/content/content/lectures/part1/02_here_we_go.md.erb
+++ b/templates/content/content/lectures/part1/02_here_we_go.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Second Lecture - Here we go
 ---
-### Continuing
+## Continuing
+
 This page is the second one in the first part. It is the second lecture of the Sample Course.

--- a/templates/content/content/lectures/part2/01_start_part2.md.erb
+++ b/templates/content/content/lectures/part2/01_start_part2.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Third Lecture - Launching Part 2
 ---
-### Part 2 starts here
+## Part 2 starts here
+
 In the sample course, there are two sections or parts. This page is the first page of the second part.

--- a/templates/content/content/lectures/part2/02_continue_part2.md.erb
+++ b/templates/content/content/lectures/part2/02_continue_part2.md.erb
@@ -1,5 +1,6 @@
 ---
 title: Fourth Lecture - Part2's second lecture
 ---
-### Second lecture of part 2
+## Second lecture of part 2
+
 This is actually the fourth lecture of the Sample course.

--- a/templates/layouts/body_header.html.erb
+++ b/templates/layouts/body_header.html.erb
@@ -1,19 +1,19 @@
-<div class="row">
+<div class="row justify-content-between">
   <div class="col-8">
-    <h3>
+    <h1>
       <%= citem.title %>
-      <span class="h6">
+      <span style="font-size: 1rem">
         <% if citem.lecture? %>
           (<%= citem.lecture_date_s %>, <%= citem.lecture_number_s.to_s %>)
         <% end %>
       </span>
-    </h3>
+    </h1>
 
   </div>
-  <div class="col pt-4">
+  <div class="col-3 pt-4">
     <%if citem.lecture? && citem.section != "root" %>
       <%= link_to_prev toc, item %> <%=link_to_next toc, item %>
     <% end %>
   </div>
 </div>
-<h6><%= citem.desc %></h6>
+<h4><%= citem.desc %></h4>

--- a/templates/layouts/course.html.erb
+++ b/templates/layouts/course.html.erb
@@ -11,7 +11,7 @@
   <%= render "/banner.*", toc: Toc.instance, item: item, citem: @citem %>
   <%= render "/nav-menus.*", toc: Toc.instance, item: item, citem: @citem %>
   <section>
-    <div class="container">
+    <div class="container DocSearch-content">
       <div class="row">
         <div class="col-md-9">
           <%= render "/body_header.*", toc: Toc.instance, item: item, citem: @citem %>
@@ -21,7 +21,6 @@
       </div>
     </div>
   </section>
-  <!-- jQuery -->
   <%= render "/bottom_includes.*" %>
   <footer>
     <%= render "/body_footer.*" %>

--- a/templates/layouts/sidebar.html.erb
+++ b/templates/layouts/sidebar.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-3  border rounded-lg sidebar">
+<div class="col-md-3 border rounded-lg sidebar">
   <% if HELPFUL_BOX %>
   <div class="row well"
     style="color: rgb(158, 48, 48);padding: 4px 8px;margin-bottom: 8px;">


### PR DESCRIPTION
This PR adds [required configuration](https://docsearch.algolia.com/docs/required-configuration/) for Docsearch, in order for coursegen-generated sites to be crawled.

All changes:
- All headings now start with `h1` instead of `h3`, when writing markdown pages please use `#` instead of `###` for the top level heading
- A `DocSearch-content` class is added to the main body of the site
- Remove legacy tiquesearch related stylings that are no longer used 