### PR TITLE
Add ability to generate slides

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coursegen (0.8.3)
+    coursegen (0.9.0)
       activesupport
       adsf
       byebug
@@ -31,7 +31,7 @@ GEM
       rack (>= 1.0.0, < 3.0.0)
     ast (2.4.0)
     byebug (11.1.3)
-    coderay (1.1.2)
+    coderay (1.1.3)
     colored (1.2)
     concurrent-ruby (1.1.6)
     cri (2.15.10)
@@ -42,7 +42,7 @@ GEM
     ddplugin (1.0.2)
     diff-lcs (1.3)
     equatable (0.6.1)
-    ffi (1.12.2)
+    ffi (1.13.1)
     formatador (0.2.5)
     guard (2.16.2)
       formatador (>= 0.2.4)
@@ -59,7 +59,7 @@ GEM
       guard-compat (~> 1.0)
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     icalendar (2.6.1)
       ice_cube (~> 0.16)
@@ -71,7 +71,7 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lumberjack (1.2.4)
+    lumberjack (1.2.5)
     method_source (1.0.0)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/coursegen.gemspec
+++ b/coursegen.gemspec
@@ -1,39 +1,38 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'coursegen/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "coursegen"
+  spec.name          = 'coursegen'
   spec.version       = Coursegen::VERSION
-  spec.authors       = ["Pito Salas"]
-  spec.email         = ["pitosalas@gmail.com"]
-  spec.summary       = "Use Nanoc to build courses and deploy them to S3"
-  spec.description   = "Use Nanoc to build courses and deploy them to S3"
-  spec.homepage      = ""
-  spec.license       = "MIT"
+  spec.authors       = ['Pito Salas']
+  spec.email         = ['pitosalas@gmail.com']
+  spec.summary       = 'Use Nanoc to build courses and deploy them to S3'
+  spec.description   = 'Use Nanoc to build courses and deploy them to S3'
+  spec.homepage      = ''
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency "nanoc"
-  spec.add_dependency "thor"
-  spec.add_dependency "rubytree"
-  spec.add_dependency "cri"
-  spec.add_dependency "nokogiri"
-  spec.add_dependency "activesupport"
-  spec.add_dependency "kramdown"
-  spec.add_dependency "adsf"
-  spec.add_dependency "guard"
-  spec.add_dependency "guard-shell"
-  spec.add_dependency "tzinfo"
-  spec.add_dependency "icalendar"
-  spec.add_dependency "byebug"
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'adsf'
+  spec.add_dependency 'byebug'
+  spec.add_dependency 'cri'
+  spec.add_dependency 'guard'
+  spec.add_dependency 'guard-shell'
+  spec.add_dependency 'icalendar'
+  spec.add_dependency 'kramdown'
+  spec.add_dependency 'nanoc'
+  spec.add_dependency 'nokogiri'
+  spec.add_dependency 'rubytree'
+  spec.add_dependency 'thor'
+  spec.add_dependency 'tzinfo'
 end

--- a/lib/coursegen/course/data/citem.rb
+++ b/lib/coursegen/course/data/citem.rb
@@ -6,7 +6,8 @@ require 'active_support/inflector'
 #
 class CItem
   attr_reader :order, :section, :subsection, :subsection_citem, :title,
-              :type, :identifier, :short_name, :status, :nitem, :css_class, :homework, :desc, :cat, :assigned
+              :type, :identifier, :short_name, :status, :nitem, :css_class,
+              :homework, :desc, :cat, :assigned, :slides
   attr_accessor :lecture_number, :lecture_date, :start_time, :end_time
 
   # Callable with nitem=nil to create a mock
@@ -86,6 +87,7 @@ class CItem
     @desc = @nitem[:desc]
     @cat = @nitem[:cat]
     @assigned = @nitem[:assigned]
+    @slides = @nitem[:slides]
   end
 
   def parse_identifier(ident)

--- a/lib/coursegen/course/helpers/bootstrap_markup.rb
+++ b/lib/coursegen/course/helpers/bootstrap_markup.rb
@@ -6,9 +6,7 @@ class BootstrapMarkup
   end
 
   def table_begin(css_class = 'table-condensed')
-    puts css_class.class
     @str << "<table class=\"table x #{css_class}\">"
-    puts @str
   end
 
   def table_end

--- a/lib/coursegen/course/helpers/content_helpers.rb
+++ b/lib/coursegen/course/helpers/content_helpers.rb
@@ -169,7 +169,7 @@ module ContentHelpers
   end
 
   def homework_hdr(show_legend: :on)
-    body = '#### Homework due for today'
+    body = '## Homework due for today'
     legend = "\n**Legend**: #{partbadge}: Participation (pass/fail) | #{pdfbadge}: PDF | #{teambadge}: Team | #{zipbadge}:  Attachment"
     body += legend if show_legend == :on
     body
@@ -333,6 +333,10 @@ module ContentHelpers
 
   def ul(body)
     "<ul>#{body}</ul>"
+  end
+
+  def slide
+    '<slide_break></slide_break>'
   end
 
   def list_items(*items)

--- a/lib/coursegen/course/helpers/navigation_helpers.rb
+++ b/lib/coursegen/course/helpers/navigation_helpers.rb
@@ -72,6 +72,15 @@ module NavigationHelpers
     end
   end
 
+  def link_to_slides
+    '<a
+      class="btn btn-sm btn-light"
+      href="./slides.html"
+      title="slides">
+      <i class="fas fa-chalkboard-teacher"></i> Slides
+    </a>'
+  end
+
   private
 
   def nav_markup(text, path, icon, tooltip = '')

--- a/lib/coursegen/version.rb
+++ b/lib/coursegen/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Coursegen
-  VERSION = '0.8.3'
+  VERSION = '0.9.0'
 end

--- a/templates/Rules
+++ b/templates/Rules
@@ -34,6 +34,16 @@ compile '/**/*.{md,ical}.erb' do
   end
 end
 
+compile '/**/*.md.erb', rep: :slides do
+  if item[:status] != "hidden"
+    filter :erb
+    layout '/slides.*'
+    write item.identifier.without_ext + '/slides.html'
+  else
+    nil
+  end
+end
+
 compile '/**/*' do
   if item.binary? || item[:status] == "hidden"
     nil

--- a/templates/content/content/lectures/part1/02_here_we_go.md.erb
+++ b/templates/content/content/lectures/part1/02_here_we_go.md.erb
@@ -1,6 +1,26 @@
 ---
 title: Second Lecture - Here we go
+desc: Advanced Features
+slides: true
 ---
 ## Continuing
 
 This page is the second one in the first part. It is the second lecture of the Sample Course.
+
+<%= slide %>
+
+## Headings
+
+# h1
+
+## h2
+
+### h3
+
+#### h4
+
+<%= slide %>
+
+## Next Lecture
+
+Click "Third Lecture" on the sidebar to go to the next lecture.

--- a/templates/layouts/body_header.html.erb
+++ b/templates/layouts/body_header.html.erb
@@ -10,10 +10,13 @@
     </h1>
 
   </div>
-  <div class="col-3 pt-4">
-    <%if citem.lecture? && citem.section != "root" %>
+  <div class="col pt-4">
+    <% if citem.lecture? && citem.section != "root" %>
+      <% if citem.slides %>
+        <%= link_to_slides %>
+      <% end %>
       <%= link_to_prev toc, item %> <%=link_to_next toc, item %>
     <% end %>
   </div>
 </div>
-<h4><%= citem.desc %></h4>
+<h3><%= citem.desc %></h3>

--- a/templates/layouts/slides.html.erb
+++ b/templates/layouts/slides.html.erb
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title><%= COURSE_SHORT_NAME %></title>
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@4.0.2/dist/reset.css">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@4.0.2/dist/reveal.css">
+  <link rel="stylesheet" href="https://unpkg.com/reveal.js@4.0.2/dist/theme/white.css" id="theme">
+  <!--[if lt IE 9]>
+  <script src="https://unpkg.com/reveal.js@4.0.2/lib/js/html5shiv.js"></script>
+  <![endif]-->
+
+  <style>
+    .scrollable {
+      bottom: 0;
+      overflow-y: auto  !important;
+      overflow-x: hidden !important;
+    }
+  </style>
+</head>
+
+<body>
+<div class="reveal">
+  <div class="slides">
+    <section data-markdown data-separator="^<slide_break></slide_break>" class="scrollable">
+      <textarea data-template>
+        <%= yield %>
+      </textarea>
+    </section>
+  </div>
+</div>
+
+<script src="https://unpkg.com/reveal.js@4.0.2/dist/reveal.js"></script>
+<!-- Plugins -->
+<script src="https://unpkg.com/reveal.js@4.0.2/plugin/markdown/markdown.js"></script>
+<script src="https://unpkg.com/reveal.js@4.0.2/plugin/highlight/highlight.js"></script>
+
+<script>
+    // Full list of configuration options available at:
+    // https://github.com/hakimel/reveal.js#configuration
+    Reveal.initialize({
+        minScale: 0.2,
+        maxScale: 1.4,
+
+        markdown: {
+            breaks: true
+        },
+
+        // Optional reveal.js plugins
+        plugins: [ RevealMarkdown, RevealHighlight ]
+    });
+</script>
+</body>


### PR DESCRIPTION
This PR adds ability to generate slides for lectures using reveal.js.

To enable slides generation functionality,

1. In the header of the file, add `slides: true`
2. In the content, use `<%= slide %>` to break content into slides

Changes

1. Add a new layout for slides
2. Add a new step in `Rules` to generate slides in addition to course html
3. Bump Coursegen version to `0.9.0`