### PR TITLE
Add enhancements for slides generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This gem is still under development. In the current form it can already be used 
 - [Examples](#examples)
   - [Lectures](#lectures)
   - [Course Sites](#course-sites)
+- [Features](#features)
+  - [Slides](#slides)
 - [Open Source Catalog of Topics](#open-source-catalog-of-topics)
 - [Using course contents from another folder](#using-course-contents-from-another-folder)
 - [License](#license)
@@ -234,6 +236,44 @@ For more complex example of lectures see [here](https://github.com/pitosalas/cos
 - An simple example: <https://github.com/pitosalas/jbscosi2014>
 - A complex example (but based on a previous version): <https://github.com/pitosalas/cosi236b>
 - The resultant web site: <https://bit.ly/cosi236b>
+
+## Features
+
+### Slides
+
+*!!! Slides generation is currently in preview stage !!!*
+
+To enable slides generation in a specific lecture, add `slides: true` to the header of the markdown file.
+
+```markdown
+---
+title: Some Lecture
+slides: true
+---
+...
+```
+
+Coursegen uses the tag `<%= slide %>` to properly separate each slide.
+
+```erb
+# Slide 1
+* some lines
+* some lines
+
+<%= slide %>
+
+# Slide 2
+* some lines
+```
+
+To disregard some content from rendering into the slides, add the html element into `cg_config.rb`.
+
+```ruby
+SLIDES_CONFIG = {
+  # This ignores any element that is <h4>
+  ignore_selector: ['h4']
+}
+```
 
 ## Open Source Catalog of Topics
 

--- a/templates/cg_config.rb
+++ b/templates/cg_config.rb
@@ -95,7 +95,20 @@ STYLING_CONFIG = {
 SEARCH_CONFIG = {
   api_key: '25626fae796133dc1e734c6bcaaeac3c',
   index_name: 'docsearch',
+
   # APP_ID is only used if you are running DocSearch on your own.
   app_id: '',
   debug: false
+}.freeze
+
+# SLIDES
+SLIDES_CONFIG = {
+  # Ignore_selectors ignore certain html elements from rendering in the slides.
+  ignore_selectors: ['h4'],
+
+  # Reveal.js specific options
+  # See: https://revealjs.com/config/
+  revealjs_opts: {
+    transition: 'slide'
+  }
 }.freeze

--- a/templates/layouts/slides.html.erb
+++ b/templates/layouts/slides.html.erb
@@ -19,6 +19,12 @@
       overflow-y: auto  !important;
       overflow-x: hidden !important;
     }
+
+    <% SLIDES_CONFIG[:ignore_selectors].each do |s| %>
+    .slides <%= s %> {
+      display: none;
+    }
+    <% end %>
   </style>
 </head>
 
@@ -49,8 +55,12 @@
             breaks: true
         },
 
+        <% SLIDES_CONFIG[:revealjs_opts].each do |k, v| %>
+        <%= k %>: <%= v.to_json %>,
+        <% end %>
+
         // Optional reveal.js plugins
         plugins: [ RevealMarkdown, RevealHighlight ]
-    });
+    })
 </script>
 </body>


### PR DESCRIPTION
This PR improves the slides generation feature.

Notably:
- Add support for ignoring certain html elements in slides
- Add ability to directly configure reveal.js from `cg_config.rb`
- Add how-to's for slides generation in readme